### PR TITLE
Update documentation to match it's Dockerfile

### DIFF
--- a/engine/examples/running_ssh_service.md
+++ b/engine/examples/running_ssh_service.md
@@ -16,7 +16,7 @@ FROM ubuntu:16.04
 RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 RUN echo 'root:screencast' | chpasswd
-RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -i 's/.*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd


### PR DESCRIPTION
The first `sed` replacement command is outdated in relation to its associated Dockerfile, and it doesn't produce the expected effect.

Looking at the docs current state, the substitution regex is taking place inside a commented line, which produces no effect at all.

### Proposed changes

Update the docs to use the same code as the Dockerfile itself, which works as expected.
